### PR TITLE
[NEC decoder] Increase initialization priority | 提高初始化优先级

### DIFF
--- a/src/nec_decoder.c
+++ b/src/nec_decoder.c
@@ -276,6 +276,6 @@ int nec_decoder_register()
     ir_decoder_register(&nec_decoder);
     return 0;
 }
-INIT_APP_EXPORT(nec_decoder_register);
+INIT_PREV_EXPORT(nec_decoder_register);
 
 #endif /* INFRARED_NEC_DECODER */


### PR DESCRIPTION
当前初始化优先级太低，导致其它应用若在初始化阶段调用`ir_select_decoder("nec")`可能会返回错误。